### PR TITLE
Changed post-sim rejection count to any rejection.

### DIFF
--- a/src/master/BeastTreeFromMaster.java
+++ b/src/master/BeastTreeFromMaster.java
@@ -95,9 +95,9 @@ public class BeastTreeFromMaster extends Tree implements StateNodeInitialiser {
                     "A post-simulation condition.",
                     new ArrayList<>());
 
-    public Input<Integer> maxPostSimConditionRejectsInput =
-            new Input<>("maxPostSimConditionRejects",
-                    "Maximum number of post simulation condition failures" +
+    public Input<Integer> maxConditionRejectsInput =
+            new Input<>("maxConditionRejects",
+                    "Maximum number of condition failures" +
                             "before aborting.  (Default is no limit.)");
 
     public Input<Boolean> samplePopulationSizesInput = new Input<>(
@@ -187,7 +187,7 @@ public class BeastTreeFromMaster extends Tree implements StateNodeInitialiser {
         for (PostSimCondition postSimCondition : postSimConditionsInput.get())
             itraj.setInputValue("postSimCondition", postSimCondition);
 
-        itraj.setInputValue("maxPostSimConditionRejects", maxPostSimConditionRejectsInput.get());
+        itraj.setInputValue("maxConditionRejects", maxConditionRejectsInput.get());
         
         for (InheritanceTrajectoryOutput output : outputsInput.get())
             itraj.setInputValue("output", output);

--- a/src/master/Ensemble.java
+++ b/src/master/Ensemble.java
@@ -94,9 +94,9 @@ public class Ensemble extends Runnable {
                     "A post-simulation condition.",
                     new ArrayList<>());
 
-    public Input<Integer> maxPostSimConditionRejectsInput =
-            new Input<>("maxPostSimConditionRejects",
-                    "Maximum number of post simulation condition failures" +
+    public Input<Integer> maxConditionRejectsInput =
+            new Input<>("maxConditionRejects",
+                    "Maximum number of condition failures" +
                             "before aborting.  (Default is no limit.)");
 
     // Outputs to write:
@@ -158,8 +158,8 @@ public class Ensemble extends Runnable {
         for (PostSimCondition condition : postSimConditionsInput.get())
             spec.addPostSimCondition(condition);
 
-        if (maxPostSimConditionRejectsInput.get() != null)
-            spec.setMaxPostSimConditionRejects(maxPostSimConditionRejectsInput.get());
+        if (maxConditionRejectsInput.get() != null)
+            spec.setMaxConditionRejects(maxConditionRejectsInput.get());
         
         // Set seed if provided, otherwise use default BEAST seed:
         if (seedInput.get()!=null)

--- a/src/master/EnsembleSummary.java
+++ b/src/master/EnsembleSummary.java
@@ -87,8 +87,8 @@ public class EnsembleSummary extends Runnable {
                     "A post-simulation condition.",
                     new ArrayList<>());
 
-    public Input<Integer> maxPostSimConditionRejectsInput =
-            new Input<>("maxPostSimConditionRejects",
+    public Input<Integer> maxConditionRejectsInput =
+            new Input<>("maxConditionRejects",
                     "Maximum number of post simulation condition failures" +
                             "before aborting.  (Default is no limit.)");
     // Individual moments:
@@ -156,8 +156,8 @@ public class EnsembleSummary extends Runnable {
         for (PostSimCondition condition : postSimConditionsInput.get())
             spec.addPostSimCondition(condition);
 
-        if (maxPostSimConditionRejectsInput.get() != null)
-            spec.setMaxPostSimConditionRejects(maxPostSimConditionRejectsInput.get());
+        if (maxConditionRejectsInput.get() != null)
+            spec.setMaxConditionRejects(maxConditionRejectsInput.get());
 
         // Check for zero-length moment and moment group lists (no point to calculation!)
         if (momentGroupsInput.get().isEmpty() && momentsInput.get().isEmpty())

--- a/src/master/InheritanceEnsemble.java
+++ b/src/master/InheritanceEnsemble.java
@@ -115,8 +115,8 @@ public class InheritanceEnsemble extends Runnable {
                     "A post-simulation condition.",
                     new ArrayList<>());
 
-    public Input<Integer> maxPostSimConditionRejectsInput =
-            new Input<>("maxPostSimConditionRejects",
+    public Input<Integer> maxConditionRejectsInput =
+            new Input<>("maxConditionRejects",
                     "Maximum number of post simulation condition failures" +
                             "before aborting.  (Default is no limit.)");
 
@@ -196,8 +196,8 @@ public class InheritanceEnsemble extends Runnable {
         for (PostSimCondition condition : postSimConditionsInput.get())
             spec.addPostSimCondition(condition);
 
-        if (maxPostSimConditionRejectsInput.get() != null)
-            spec.setMaxPostSimConditionRejects(maxPostSimConditionRejectsInput.get());
+        if (maxConditionRejectsInput.get() != null)
+            spec.setMaxConditionRejects(maxConditionRejectsInput.get());
 
         // Set seed if provided, otherwise use default BEAST seed:
         if (seedInput.get()!=null)

--- a/src/master/InheritanceTrajectory.java
+++ b/src/master/InheritanceTrajectory.java
@@ -170,8 +170,8 @@ public class InheritanceTrajectory extends Trajectory {
         for (PostSimCondition condition : postSimConditionsInput.get())
             spec.addPostSimCondition(condition);
 
-        if (maxPostSimConditionRejectsInput.get() != null)
-            spec.setMaxPostSimConditionRejects(maxPostSimConditionRejectsInput.get());
+        if (maxConditionRejectsInput.get() != null)
+            spec.setMaxConditionRejects(maxConditionRejectsInput.get());
 
         // Set seed if provided, otherwise use default BEAST seed:
         if (seedInput.get()!=null)
@@ -191,7 +191,7 @@ public class InheritanceTrajectory extends Trajectory {
         try {
             simulate();
         } catch (RejectCountExceeded ex) {
-            System.err.println("Maximum number of post-simulation condition " +
+            System.err.println("Maximum number of condition " +
                     "rejections exceeded. Aborting.");
             System.exit(1);
         }
@@ -236,7 +236,7 @@ public class InheritanceTrajectory extends Trajectory {
             sampleDt = spec.getSampleDt();
 
         boolean postSimReject;
-        int postSimRejectCount = 0;
+        int rejectCount = 0;
         do { // Perform simulations until no post-simulation rejection occurs
             
             initialiseSimulation();
@@ -288,7 +288,14 @@ public class InheritanceTrajectory extends Trajectory {
                         // Rejection: Abort and start a new simulation
                         if (spec.getVerbosity()>0)
                             System.err.println("Rejection end condition met "
-                                    + "at time " + t);   
+                                    + "at time " + t);
+                        rejectCount += 1;
+
+                        if (spec.getMaxConditionRejects()>=0 &&
+                                rejectCount > spec.getMaxConditionRejects()) {
+                            throw new RejectCountExceeded();
+                        }
+
                         initialiseSimulation();
                         continue;
                     } else {
@@ -448,10 +455,10 @@ public class InheritanceTrajectory extends Trajectory {
                 if (spec.getVerbosity()>0)
                     System.err.println("Post-simulation rejection condition met.");
 
-                postSimRejectCount += 1;
+                rejectCount += 1;
 
-                if (spec.getMaxPostSimConditionRejects()>=0 &&
-                        postSimRejectCount > spec.getMaxPostSimConditionRejects()) {
+                if (spec.getMaxConditionRejects()>=0 &&
+                        rejectCount > spec.getMaxConditionRejects()) {
                     throw new RejectCountExceeded();
                 }
 

--- a/src/master/Trajectory.java
+++ b/src/master/Trajectory.java
@@ -91,8 +91,8 @@ public class Trajectory extends Runnable {
                     "A post-simulation condition.",
                     new ArrayList<>());
 
-    public Input<Integer> maxPostSimConditionRejectsInput =
-            new Input<>("maxPostSimConditionRejects",
+    public Input<Integer> maxConditionRejectsInput =
+            new Input<>("maxConditionRejects",
                     "Maximum number of post simulation condition failures" +
                             "before aborting.  (Default is no limit.)");
     
@@ -167,8 +167,8 @@ public class Trajectory extends Runnable {
         for (PostSimCondition condition : postSimConditionsInput.get())
             spec.addPostSimCondition(condition);
 
-        if (maxPostSimConditionRejectsInput.get() != null)
-            spec.setMaxPostSimConditionRejects(maxPostSimConditionRejectsInput.get());
+        if (maxConditionRejectsInput.get() != null)
+            spec.setMaxConditionRejects(maxConditionRejectsInput.get());
 
         // Set seed if provided, otherwise use default BEAST seed:
         if (seedInput.get()!=null)
@@ -188,7 +188,7 @@ public class Trajectory extends Runnable {
         try {
             simulate();
         } catch (RejectCountExceeded ex) {
-            System.err.println("Maximum number of post-simulation condition " +
+            System.err.println("Maximum number of condition " +
                     "rejections exceeded. Aborting.");
             System.exit(1);
         }
@@ -233,7 +233,7 @@ public class Trajectory extends Runnable {
         
         // Loop until any post-simulation rejection conditions fail.
         boolean postSimulationReject;
-        int postSimRejectCount = 0;
+        int rejectCount = 0;
         do {
             sampledStates.clear();
             sampledTimes.clear();
@@ -282,7 +282,15 @@ public class Trajectory extends Runnable {
                         if (endConditionMet.isRejection()) {
                             if (spec.verbosity>0)
                                 System.err.println("Rejection end condition met "
-                                        + "at time " + t);   
+                                        + "at time " + t);
+
+                            rejectCount += 1;
+
+                            if (spec.getMaxConditionRejects()>=0 &&
+                                    rejectCount > spec.getMaxConditionRejects()) {
+                                throw new RejectCountExceeded();
+                            }
+
                             currentState = new PopulationState(spec.initPopulationState);
                             clearSamples();
                             sampleState(currentState, 0.0);
@@ -365,10 +373,10 @@ public class Trajectory extends Runnable {
                 if (spec.getVerbosity()>0)
                     System.err.println("Post-simulation rejection condition met.");
 
-                postSimRejectCount += 1;
+                rejectCount += 1;
 
-                if (spec.getMaxPostSimConditionRejects()>=0 &&
-                        postSimRejectCount > spec.getMaxPostSimConditionRejects()) {
+                if (spec.getMaxConditionRejects()>=0 &&
+                        rejectCount > spec.getMaxConditionRejects()) {
                     throw new RejectCountExceeded();
                 }
             }

--- a/src/master/TrajectorySpec.java
+++ b/src/master/TrajectorySpec.java
@@ -66,7 +66,7 @@ public class TrajectorySpec {
     // Leaf count post-simulation conditions:
     List<PostSimCondition> postSimConditions;
 
-    int maxPostSimConditionRejects = -1;
+    int maxConditionRejects = -1;
 
     
     // Whether to collect evenly spaced samples or let the state stepper
@@ -201,8 +201,8 @@ public class TrajectorySpec {
      *
      * @param n limit to set
      */
-    public void setMaxPostSimConditionRejects(int n) {
-        maxPostSimConditionRejects = n;
+    public void setMaxConditionRejects(int n) {
+        maxConditionRejects = n;
     }
 
      /**
@@ -210,8 +210,8 @@ public class TrajectorySpec {
      * aborting. A value of -1 implies no limit.
      *
      */
-    public int getMaxPostSimConditionRejects() {
-        return maxPostSimConditionRejects;
+    public int getMaxConditionRejects() {
+        return maxConditionRejects;
     }
 
     /**


### PR DESCRIPTION
I've made the rejection counter count any rejection at all, since in my case it is actually the LineageEndCondition (one of the lineages dies out) that is stopping the simulation from running successfully.